### PR TITLE
Fixed utf-8 decoding error

### DIFF
--- a/vdu_controls.py
+++ b/vdu_controls.py
@@ -1204,7 +1204,7 @@ class DdcUtil:
                 result = subprocess.run(process_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
                 # Shorten EDID to 30 characters when logging it (it will be the only long argument)
                 log_debug("subprocess result: ", self.format_args_diagnostic(result.args),
-                          f"rc={result.returncode}", f"stdout={result.stdout.decode('utf-8')}") if log_debug_enabled else None
+                          f"rc={result.returncode}", f"stdout={result.stdout.decode('utf-8', errors='replace')}") if log_debug_enabled else None
             except subprocess.SubprocessError as spe:
                 error_text = spe.stderr.decode('utf-8')
                 if error_text.lower().find("display not found") >= 0:  # raise DdcUtilDisplayNotFound and stay quiet
@@ -1224,7 +1224,7 @@ class DdcUtil:
         rubbish = re.compile('[^a-zA-Z0-9]+')
         # This isn't efficient, it doesn't need to be, so I'm keeping re-defs close to where they are used.
         key_prospects: Dict[Tuple[str, str], Tuple[str, str]] = {}
-        for display_str in re.split("\n\n", result.stdout.decode('utf-8')):
+        for display_str in re.split("\n\n", result.stdout.decode('utf-8', errors='replace')):
             display_match = re.search(r'Display ([0-9]+)', display_str)
             if display_match is not None:
                 vdu_id = display_match.group(1)


### PR DESCRIPTION
Fixed this error:

ERROR: 'utf-8' codec can't decode byte 0x80 in position 2818: invalid start byte

It happens because indeed there is a 0x80 byte in the middle of `Extra descriptor` at the EDID information. Look:

![image](https://github.com/digitaltrails/vdu_controls/assets/121676/0e291900-2a50-43b9-b3c8-d2f4b1ec80e3)

```
   EDID hex dump:
              +0          +4          +8          +c            0   4   8   c   
      +0000   00 ff ff ff ff ff ff 00 06 af 2d 56 00 00 00 00   ..........-V....
      +0010   00 1c 01 04 a5 1d 11 78 02 ee 95 a3 54 4c 99 26   .......x....TL.&
      +0020   0f 50 54 00 00 00 01 01 01 01 01 01 01 01 01 01   .PT.............
      +0030   01 01 01 01 01 01 b4 37 80 a0 70 38 3e 40 3a 2a   .......7..p8>@:*
      +0040   35 00 25 a5 10 00 00 1a b4 37 80 a0 70 38 5c 41   5.%......7..p8\A
      +0050   3a 2a 35 00 25 a5 10 00 00 1a 00 00 00 fe 00 38   :*5.%..........8
      +0060   34 58 46 37 80 42 31 33 33 48 41 4e 00 00 00 00   4XF7.B133HAN....
      +0070   00 02 41 03 9e 00 11 00 00 0a 01 0a 20 20 00 c4   ..A.........  ..
```

This, by the way, is reported as *Invalid display*, because *This is an eDP laptop display. Laptop displays do not support DDC/CI.*

---

Bonus: Tracking down this error was annoying because the `try…except` block at line 6531 swallows the stacktrace. I managed to view the stacktrace by adding a plain `raise` line in the `except` block, effectively re-throwing the error. Maybe the stacktrace should be printed if `--debug` is passed. I'll leave the implementation as an exercise to someone else. ;)