### PR TITLE
Setting icon font weight to Medium

### DIFF
--- a/vdu_controls.py
+++ b/vdu_controls.py
@@ -4932,6 +4932,7 @@ def create_icon_from_text(text: str, themed: bool = True) -> QIcon:
     painter = QPainter(pixmap)
     font = QApplication.font()
     font.setPixelSize(24)
+    font.setWeight(QFont.Medium)
     painter.setFont(font)
     painter.setOpacity(1.0)
     painter.setPen(QColor((SVG_DARK_THEME_COLOR if themed and is_dark_theme() else SVG_LIGHT_THEME_COLOR).decode("utf-8")))


### PR DESCRIPTION
It seems the default font weight is Normal or 400. Changing it to Medium (500) seem to make the text more visible. The rendered text looks less thin and less gray, and instead looks more black without looking too bold. Setting it to DemiBold(600) looks the same as Medium. Setting it to Bold (700) is too much.

https://doc.qt.io/qtforpython-6/PySide6/QtGui/QFont.html#PySide6.QtGui.PySide6.QtGui.QFont.Weight

https://github.com/digitaltrails/vdu_controls/issues/55#issuecomment-1733889397