### PR TITLE
Fix undefined values preventing tool from opening

### DIFF
--- a/vdu_controls.py
+++ b/vdu_controls.py
@@ -3116,7 +3116,7 @@ class VduControlComboBox(VduControlBase):
         """Copy the internally cached current value onto the GUI view."""
         self.validate_value()
         value = self.get_current_text_value()
-        if value is not None:
+        if (value is not None) and (value in self.keys):
             self.combo_box.setCurrentIndex(self.keys.index(value))
 
     def validate_value(self) -> None:


### PR DESCRIPTION
Just got an AW3225QF, and vdu controls complains about an input source undefined value F0F and mentions that you can override the settings in the options panel.  But immediately after dismissing that it then crashes when it tries to find the undefined value in the values list.  This additional check prevents the invalid list look up and allows the UI to open so that you can get into the settings and change the overrides.

If self.keys can never contain None then it would probably be cleaner to keep only the list contains check and get rid of the nonetype test, since the second test would then cover both cases.