### PR TITLE
Fix exception on monitors with empty capability descriptions

### DIFF
--- a/vdu_controls.py
+++ b/vdu_controls.py
@@ -2471,7 +2471,7 @@ class VduController(QObject):
                         space_separated = lines_list[0].replace('(interpretation unavailable)', '').strip().split(' ')
                         values_list = [(v.upper(), 'unknown ' + v) for v in space_separated[1:]]
                 else:
-                    values_list = [(key.upper(), desc) for key, desc in (v.strip().split(": ", 1) for v in lines_list[1:])]
+                    values_list = [(key.upper(), desc.strip()) for key, desc in (v.strip().split(":", 1) for v in lines_list[1:])]
             return values_list
 
         feature_map = {}


### PR DESCRIPTION
Stripping the value before splitting results in an exception when the description is empty:

```
10:45:59 ERROR: Problem creating controller for vdu_number='1' model_name='PHL_279M1RV' vdu_serial='1010101' exception=not enough values to unpack (expected 2, got 1)
```