### PR TITLE
Fix crash from accessing QLocale.MetricSystem

### DIFF
--- a/vdu_controls.py
+++ b/vdu_controls.py
@@ -4845,7 +4845,7 @@ class WeatherQuery:
 
 def weather_bad_location_dialog(weather) -> None:
     kilometres = weather.proximity_km
-    use_km = QLocale.system().measurementSystem() == QLocale.MetricSystem
+    use_km = QLocale.system().measurementSystem() == QLocale.MeasurementSystem.MetricSystem
     MBox(MIcon.Warning, msg=tr("The site {} reports your location as {}, {}, {},{} "
                               "which is about {} {} from the latitude and longitude specified in Settings."
                               ).format(WEATHER_FORECAST_URL, weather.area_name, weather.country_name, weather.latitude, weather.longitude,


### PR DESCRIPTION
Fixes error

    AttributeError: type object 'QLocale' has no attribute 'MetricSystem'

when the `location` is set in the settings.

Fixes the **Presets** window not opening. Not sure how that worked for anybody so far though -- was the code never run with a `location` set in the settings?

In my Python3 on Ubuntu 24.04:

```
>>> QLocale.MeasurementSystem.MetricSystem
<MeasurementSystem.MetricSystem: 0>

>>> QLocale.MetricSystem
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: type object 'QLocale' has no attribute 'MetricSystem'
```

