### PR TITLE
Single-instance guard: raise existing window instead of starting a duplicate

### DIFF
--- a/src/vdu_controls/vdu_controls_application.py
+++ b/src/vdu_controls/vdu_controls_application.py
@@ -1532,6 +1532,49 @@ class SignalWakeupHandler(QtNetwork.QAbstractSocket):
         self.received_unix_signal_qtsignal.emit(signal_number)  # Emit a Qt signal for convenience
 
 
+class SingleInstanceServer(QObject):
+    # Listens on a per-user QLocalServer socket so a second vdu_controls launch can ask the
+    # running instance to surface its main window instead of starting a duplicate process.
+    # Two startup channels routinely coexist on KDE (XDG autostart + ksmserver session-restore),
+    # plus manual menu clicks; without this guard each becomes its own independent process.
+
+    activate_requested = pyqtSignal()
+
+    def __init__(self, server_name: str, parent: QObject | None = None) -> None:
+        super().__init__(parent)
+        self._server = QtNetwork.QLocalServer(self)
+        self._server.newConnection.connect(self._on_new_connection)
+        if not self._server.listen(server_name):
+            # listen() failed - typically a stale socket from a crashed prior run.  Remove and retry.
+            # (A true race with a concurrent launch is handled by the caller's pre-check via
+            # _activate_running_instance, which runs before constructing this server.)
+            QtNetwork.QLocalServer.removeServer(server_name)
+            if not self._server.listen(server_name):
+                log.warning(f"Single-instance guard could not bind {server_name}: {self._server.errorString()}")
+
+    def _on_new_connection(self) -> None:
+        while self._server.hasPendingConnections():
+            sock = self._server.nextPendingConnection()
+            if sock is not None:
+                sock.readAll()
+                sock.disconnectFromServer()
+        self.activate_requested.emit()
+
+
+def _activate_running_instance(server_name: str, timeout_ms: int = 500) -> bool:
+    # Try to contact a running vdu_controls and ask it to raise its main window.
+    # Returns True if a peer accepted the request (caller should exit), False if no peer was reachable.
+    sock = QtNetwork.QLocalSocket()
+    sock.connectToServer(server_name)
+    if not sock.waitForConnected(timeout_ms):
+        return False
+    sock.write(b"activate\n")
+    sock.flush()
+    sock.waitForBytesWritten(timeout_ms)
+    sock.disconnectFromServer()
+    return True
+
+
 def get_app_instance() -> QApplication:
     app_instance = cast(QApplication, QApplication.instance())
     assert app_instance is not None
@@ -1615,6 +1658,15 @@ def main() -> None:
         print(app_locale.load_docs_text(HELP_FILENAME))
         sys.exit()
 
+    # Single-instance guard: if another vdu_controls is already running, ask it to surface its
+    # main window and exit.  Placed after the one-shot CLI ops (--install, --uninstall,
+    # --detailed-help) so those still work regardless.
+    single_instance_name = f"vdu_controls-{os.geteuid()}"
+    if _activate_running_instance(single_instance_name):
+        log.info(f"Another {APPNAME} instance is already running; activated it and exiting.")
+        sys.exit(0)
+    single_instance_server = SingleInstanceServer(single_instance_name, parent=app)
+
     if main_config.is_set(ConfOpt.TRANSLATIONS_ENABLED):
         initialise_locale_translations(app)
     else:
@@ -1622,7 +1674,8 @@ def main() -> None:
 
     main_controller = VduAppController(main_config)
     assert gui_misc.is_running_in_gui_thread()
-    VduAppWindow(main_config, main_controller)  # may need to assign this to a variable to prevent garbage collection?
+    main_window = VduAppWindow(main_config, main_controller)  # may need to assign this to a variable to prevent garbage collection?
+    single_instance_server.activate_requested.connect(partial(main_window.show_main_window, False))
 
     if args.about:
         AboutDialog.show_dialog(main_controller)

--- a/tests/test_single_instance.py
+++ b/tests/test_single_instance.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2021-2026 Contributors to vdu_controls <https://github.com/digitaltrails/vdu_controls>
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Headless IPC tests for the single-instance guard.
+# Run:  PYTHONPATH=$(pwd)/src python3 tests/test_single_instance.py
+import os
+import subprocess
+import sys
+import textwrap
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from vdu_controls.qt_imports import QApplication, QtNetwork
+from vdu_controls.vdu_controls_application import SingleInstanceServer, _activate_running_instance
+
+PID = os.getpid()
+PASS, FAIL = "\033[32mPASS\033[0m", "\033[31mFAIL\033[0m"
+
+
+def _spin(app, predicate, timeout_s: float = 2.0, step_s: float = 0.02) -> bool:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        app.processEvents()
+        if predicate():
+            return True
+        time.sleep(step_s)
+    return False
+
+
+def test_no_existing_instance(app) -> None:
+    name = f"vdu_controls-test-{PID}-a"
+    QtNetwork.QLocalServer.removeServer(name)
+    found = _activate_running_instance(name, timeout_ms=200)
+    assert not found, "expected False when no server is listening"
+
+
+def test_server_emits_activate_on_request(app) -> None:
+    name = f"vdu_controls-test-{PID}-b"
+    QtNetwork.QLocalServer.removeServer(name)
+    server = SingleInstanceServer(name)
+    assert server._server.isListening(), "server did not start listening"
+    activations: list[bool] = []
+    server.activate_requested.connect(lambda: activations.append(True))
+
+    found = _activate_running_instance(name, timeout_ms=500)
+    assert found, "_activate_running_instance should have returned True"
+    assert _spin(app, lambda: bool(activations)), "activate_requested was never emitted"
+    server._server.close()
+
+
+def test_two_clients_each_activate(app) -> None:
+    name = f"vdu_controls-test-{PID}-c"
+    QtNetwork.QLocalServer.removeServer(name)
+    server = SingleInstanceServer(name)
+    activations: list[int] = []
+    server.activate_requested.connect(lambda: activations.append(len(activations) + 1))
+
+    for _ in range(2):
+        assert _activate_running_instance(name, timeout_ms=500)
+    assert _spin(app, lambda: len(activations) >= 2), f"expected 2 activations, got {activations}"
+    server._server.close()
+
+
+def test_stale_socket_recovery(app) -> None:
+    # Spawn a subprocess that binds a QLocalServer and then dies abruptly (SIGKILL).
+    # Whether the kernel leaves a stale socket file depends on Qt's cleanup; the SingleInstanceServer
+    # fallback (removeServer + retry listen) should make either outcome work.
+    name = f"vdu_controls-test-{PID}-d"
+    QtNetwork.QLocalServer.removeServer(name)
+    script = textwrap.dedent(f"""
+        import sys, time
+        sys.path.insert(0, {str(REPO_ROOT / 'src')!r})
+        from vdu_controls.qt_imports import QApplication, QtNetwork
+        app = QApplication([])
+        srv = QtNetwork.QLocalServer()
+        assert srv.listen({name!r}), srv.errorString()
+        print("READY", flush=True)
+        time.sleep(30)
+    """)
+    proc = subprocess.Popen(
+        [sys.executable, "-c", script],
+        stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True,
+        env={**os.environ, "QT_QPA_PLATFORM": "offscreen"},
+    )
+    try:
+        assert proc.stdout is not None
+        # qt_imports prints "Trying Qt6"/"Trying Qt5" before our marker - skip until READY
+        ready = False
+        deadline = time.monotonic() + 10.0
+        while time.monotonic() < deadline:
+            line = proc.stdout.readline().strip()
+            if line == "READY":
+                ready = True
+                break
+        assert ready, "subprocess never printed READY"
+        proc.kill()
+        proc.wait(timeout=5)
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+
+    # Some Qt versions clean up on process exit; others don't.  The fallback must handle either.
+    server = SingleInstanceServer(name)
+    assert server._server.isListening(), f"SingleInstanceServer failed to bind after stale: {server._server.errorString()}"
+    # And the recovered server should be reachable.
+    activations: list[bool] = []
+    server.activate_requested.connect(lambda: activations.append(True))
+    assert _activate_running_instance(name, timeout_ms=500), "recovered server unreachable"
+    assert _spin(app, lambda: bool(activations)), "recovered server did not emit activate_requested"
+    server._server.close()
+
+
+def main() -> int:
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")  # no display needed
+    app = QApplication(sys.argv)
+    tests = [
+        ("no existing instance -> activate returns False", test_no_existing_instance),
+        ("server emits activate_requested on connection", test_server_emits_activate_on_request),
+        ("two activations from same server", test_two_clients_each_activate),
+        ("stale socket recovery via removeServer + retry", test_stale_socket_recovery),
+    ]
+    failures = 0
+    for name, fn in tests:
+        try:
+            fn(app)
+            print(f"  {PASS}  {name}")
+        except AssertionError as e:
+            print(f"  {FAIL}  {name}: {e}")
+            failures += 1
+        except Exception as e:
+            print(f"  {FAIL}  {name}: {type(e).__name__}: {e}")
+            failures += 1
+    print(f"\n{len(tests) - failures}/{len(tests)} passed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #129.

## Summary
Adds a `QLocalServer`-based single-instance guard in `vdu_controls_application`:

- `SingleInstanceServer` listens on a per-user socket (`vdu_controls-<uid>`) once
  the first instance starts.
- On startup, `_activate_running_instance` probes that socket. If a peer accepts,
  the new process sends `"activate\n"` and exits. The running instance receives a
  `newConnection`, emits `activate_requested`, and `show_main_window()` raises the
  window (restoring it from the tray if hidden).
- Stale sockets from a crashed prior run are handled by a `removeServer` + retry
  fallback when `listen()` fails.

Placed after the one-shot CLI ops (`--install`, `--uninstall`, `--detailed-help`)
so those still work regardless. Per-uid socket name keeps multi-user systems
independent. No new dependencies — `QLocalServer`/`QLocalSocket` are in `QtNetwork`,
already imported.

## Test plan
- [x] `tests/test_single_instance.py` (new) — 4 headless IPC tests covering:
      no-existing-instance, server activation, two sequential activations, and
      stale-socket recovery after `SIGKILL` of a prior server subprocess.
      Run: `PYTHONPATH=$(pwd)/src python3 tests/test_single_instance.py`
- [x] Manual on KDE Plasma X11: cold start, second-launch detect-and-exit, and
      kill-then-relaunch recovery all behave as expected.

## Notes
- The guard is fix-vs-fix: pre-existing unfixed instances at the time of upgrade
  remain invisible to it (they don't run a `QLocalServer`).
- Race window between the `_activate_running_instance` probe and `listen()` is
  microsecond-scale; in practice login-time channels fire hundreds of ms apart
  so this is well-covered.