### PR TITLE
Fix crash on Qt < 6.6: guard QMessageBox.Option access in MBox

### DIFF
--- a/src/vdu_controls/widgets.py
+++ b/src/vdu_controls/widgets.py
@@ -242,7 +242,7 @@ class MBox(QMessageBox):
         # DontUseNativeDialog is not available on deepin, so check for that.
         #
         # TODO Add an environment-toggle and see if this is KDE only.
-        if hasattr(QMessageBox.Option, 'DontUseNativeDialog'):
+        if hasattr(QMessageBox, 'Option') and hasattr(QMessageBox.Option, 'DontUseNativeDialog'):
             self.setOption(QMessageBox.Option.DontUseNativeDialog, True)
         self.setAttribute(Qt.WidgetAttribute.WA_QuitOnClose, False)
         if MBox.translating:


### PR DESCRIPTION
## Summary

`MBox.__init__` (the base class for every message dialog in vdu_controls) unconditionally evaluates `QMessageBox.Option` to guard the KDE `DontUseNativeDialog` workaround. `QMessageBox.Option` and `QMessageBox.setOption()` were only added in **Qt 6.6**, so on Qt < 6.6 evaluating `QMessageBox.Option` raises `AttributeError` — which crashes the app whenever any `MBox` is shown (e.g. the release-notes popup on a version change; the exception handler then tries to show another `MBox` and dies the same way).

## Environment where it reproduces

- Qt 6.4.2 / PyQt6 6.6.1, KDE Plasma (X11)
- Any Qt build older than 6.6

## Traceback

```
File ".../widgets.py", line 245, in __init__
    if hasattr(QMessageBox.Option, 'DontUseNativeDialog'):
AttributeError: type object 'QMessageBox' has no attribute 'Option'
```

## Fix

Check that `QMessageBox` actually exposes the `Option` enum before touching it, so the KDE workaround is applied on Qt >= 6.6 and skipped gracefully on older Qt:

```python
if hasattr(QMessageBox, 'Option') and hasattr(QMessageBox.Option, 'DontUseNativeDialog'):
    self.setOption(QMessageBox.Option.DontUseNativeDialog, True)
```

Verified on Qt 6.4.2: the app now launches and the release-notes dialog renders correctly instead of crashing.
